### PR TITLE
Authenticated Socket Messaging

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -21,6 +21,7 @@ socketio = SocketIO(app)
 def initialize():
     _initialize_logging()
     _initialize_resources()
+    _initialize_socketio()
 
     socketio.run(app)
 
@@ -33,3 +34,7 @@ def _initialize_resources():
     api.add_resource(User, '/users')
     from app.auth import BasicAuth
     api.add_resource(BasicAuth, '/auth')
+    
+def _initialize_socketio():
+    from app.sockets import SocketSetupService
+    SocketSetupService.setup_handlers(socketio)

--- a/app/auth/decorators.py
+++ b/app/auth/decorators.py
@@ -1,0 +1,60 @@
+import functools
+from json import loads
+from flask import request
+from app.common import errors, exceptions, utils
+from app.auth.service import AuthService
+
+def authenticated_request(f):
+    """
+    Ensures that an incoming request provides a valid
+    authentication token
+    TODO: Test to ensure functionality works
+    """
+    
+    @functools.wraps(f)
+    def wrapped(*args, **kwargs):
+        auth_service = AuthService()
+        auth_token = auth_service.extract_token(request)
+        if not auth_token:
+            message = "This resource cannot be accessed without a valid authentication token"
+            source = auth_service.AUTH_HEADER_KEY
+            return utils.make_error(errors.MissingParameterError(message, source))
+        
+        payload = None
+        try:
+            payload = auth_service.validate_token(auth_token)
+        except exceptions.TokenValidationExeception, e:
+            message = e.message
+            source = auth_service.AUTH_HEADER_KEY
+            return utils.make_error(errors.InvalidParameterError(message, source))
+        
+        kwargs['user'] = payload
+        return f(*args, **kwargs)
+    return wrapped
+
+def authenticated_event(f):
+    @functools.wraps(f)
+    def wrapped(*args, **kwargs):
+        auth_service = AuthService()
+        
+        data = args['data']
+        auth_token = None
+        if data:
+            data = loads(data)
+            auth_token = data['token']
+            kwargs['data'] = data
+            
+        if not auth_token:
+            message = "This resource cannot be accessed without a valid authentication token"
+            kwargs['error'] = message
+        
+        payload = None
+        try:
+            payload = auth_service.validate_token(auth_token)
+            kwargs['user'] = payload
+        except exceptions.TokenValidationExeception, e:
+            message = e.message
+            kwargs['error'] = message
+        
+        return f(*args, **kwargs)
+    return wrapped

--- a/app/auth/service.py
+++ b/app/auth/service.py
@@ -10,15 +10,20 @@ class AuthService(object):
 
 	_secret = config.SECRET_KEY
 	_params = config.JWT_PARAMS
+	
+	AUTH_HEADER_KEY = "Authorization"
 
 	def __init__(self):
 		pass
+	
+	def extract_token(self, request):
+		return request.headers.get(AUTH_HEADER_KEY)
 
 	def make_token(self, user):
 		payload = {
 				'sub': user.id,
 				'email': user.email,
-				'exp': datetime.datetime.utcnow() + datetime.timedelta(days = self._params['EXPIRATION_IN_DAYS'])
+				'exp': datetime.datetime.utcnow() + datetime.timedelta(days=self._params['EXPIRATION_IN_DAYS'])
 			}
 
 
@@ -27,8 +32,9 @@ class AuthService(object):
 	def validate_token(self, token):
 		try:
 			payload = jwt.decode(token, algorithms=[self._params['ALGORITHM']])
+			return payload
 		except jwt.DecodeError:
-			message = 'The provided token is invalid'
+			message = 'The provided token was invalid'
 			raise exceptions.TokenValidationExeception(message)
 		except jwt.InvalidTokenError:
 			message = 'The provided token could not be decoded'

--- a/app/auth/service.py
+++ b/app/auth/service.py
@@ -31,11 +31,11 @@ class AuthService(object):
 
 	def validate_token(self, token):
 		try:
-			payload = jwt.decode(token, algorithms=[self._params['ALGORITHM']])
+			payload = jwt.decode(token, self._secret, algorithms=[self._params['ALGORITHM']])
 			return payload
 		except jwt.DecodeError:
 			message = 'The provided token was invalid'
-			raise exceptions.TokenValidationExeception(message)
+			raise exceptions.TokenValidationException(message)
 		except jwt.InvalidTokenError:
 			message = 'The provided token could not be decoded'
-			raise exceptions.TokenValidationExeception(message)
+			raise exceptions.TokenValidationException(message)

--- a/app/common/errors.py
+++ b/app/common/errors.py
@@ -68,9 +68,24 @@ class InvalidHeaderError(_BaseError):
     def __init__(self, message, source):
         type = 'InvalidHeaderError'
         if not message:
-            message = 'One or more headers were missing from the request'
+            message = 'One or more headers in the request were invalid'
         status = 400
         code = 103
+
+        super(InvalidHeaderError, self).__init__(type, message, status, code, source)
+        
+class MissingHeaderError(_BaseError):
+    """
+    An error indicating that the client did not provide one or
+    more required headers
+    """
+
+    def __init__(self, message, source):
+        type = 'MissingHeaderError'
+        if not message:
+            message = 'One or more headers were missing from the request'
+        status = 400
+        code = 104
 
         super(InvalidHeaderError, self).__init__(type, message, status, code, source)
 

--- a/app/sockets/__init__.py
+++ b/app/sockets/__init__.py
@@ -1,28 +1,30 @@
 from json import loads
-from flask.ext.socketio import emit
+from flask.ext.socketio import emit, join_room, leave_room
 from app.auth.decorators import authenticated_event
-
+    
 class SocketSetupService(object):
     """
     Handles all operations related to socketio handler setup
     """
-
+ 
     @staticmethod
     def setup_handlers(socketio):
         
-        @socketio.on('connection')     
+        @socketio.on('join', namespace="/mvp")
         @authenticated_event
-        def handle_connection(raw_data, data = None, user = None, error = None):
+        def handle_join(raw_data, data = None, user = None, error = None):
             if error:
-                emit('error', error)
-            else:
-                print(str(user) + " has connected")
-
-        @socketio.on('updated')
-        def handle_update(json):
-            data = loads(json)
-            emit('updated', data, broadcast=True)
-
+                return emit('error', error)
+            
+            requested_room = data.get('room')
+            if requested_room != 'default':
+                # we will only restrict the room for the MVP
+                error = "Sorry, but only the 'default' room is available"
+                return emit('error', error)
+            
+            join_room(requested_room)
+            emit('joined', {'room': requested_room})
+ 
         @socketio.on('sent')
         def handle_send(json):
             data = loads(json)

--- a/app/sockets/__init__.py
+++ b/app/sockets/__init__.py
@@ -5,6 +5,9 @@ from app.auth.decorators import authenticated_event
 class SocketSetupService(object):
     """
     Handles all operations related to socketio handler setup
+    Note: this is to be used in its current state for the MVP
+    ONLY. The functionality has not been throughly tested enough
+    to leave it as-is
     """
  
     @staticmethod
@@ -25,7 +28,15 @@ class SocketSetupService(object):
             join_room(requested_room)
             emit('joined', {'room': requested_room})
  
-        @socketio.on('sent')
-        def handle_send(json):
+        @socketio.on('updated', namespace="/mvp")
+        def handle_update(json):
             data = loads(json)
-            emit('sent', data, broadcast=True)
+            data = {"message": data.get('message'), "sender": data.get("sender")}
+            emit('updated', data, room=data.get("room"), broadcast=True)
+            
+        @socketio.on('sent', namespace="/mvp")
+        def handle_send(json):
+            #violating DRY in order to get the MVP done faster
+            data = loads(json)
+            data = {"message": data.get('message'), "sender": data.get("sender")}
+            emit('sent', data, room=data.get("room"), broadcast=True)

--- a/app/sockets/__init__.py
+++ b/app/sockets/__init__.py
@@ -1,0 +1,29 @@
+from json import loads
+from flask.ext.socketio import emit
+from app.auth.decorators import authenticated_event
+
+class SocketSetupService(object):
+    """
+    Handles all operations related to socketio handler setup
+    """
+
+    @staticmethod
+    def setup_handlers(socketio):
+        
+        @socketio.on('connection')     
+        @authenticated_event
+        def handle_connection(raw_data, data = None, user = None, error = None):
+            if error:
+                emit('error', error)
+            else:
+                print(str(user) + " has connected")
+
+        @socketio.on('updated')
+        def handle_update(json):
+            data = loads(json)
+            emit('updated', data, broadcast=True)
+
+        @socketio.on('sent')
+        def handle_send(json):
+            data = loads(json)
+            emit('sent', data, broadcast=True)

--- a/test/socket_test.html
+++ b/test/socket_test.html
@@ -12,32 +12,83 @@
 </head>
 <body>
   <h1>Status</h1>
-  <p id="status">Connecting...</p>
-  <p id="tip"></p>
+  <div>
+  	<p id="status">Connecting...</p>
+  </div>
+  <form id="authForm" style="display:none">
+  	<input id="jwt" placeholder="Authentication Token" autocomplete="off">
+  	<button>Sign In</button>
+  </form>
+  <form id="messageForm" style="display:none">
+    <input id="message" autocomplete="off" />
+    <button>Send</button>
+  </form>
   <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/socket.io/0.9.16/socket.io.min.js"></script>
+  <script src="http://code.jquery.com/jquery-latest.min.js"></script>
   <script type="text/javascript" charset="utf-8">
   	var statusElement = document.getElementById("status");
   	var tipElement = document.getElementById("tip");
+  	var authFormElement = document.getElementById("authForm");
+    var messageFormElement = document.getElementById("messageForm");
+    
   	try {
-  		setTimeout(function(){ 
-  			if (statusElement.innerHTML.toLowerCase() === 'connecting...') {
-  				tipElement.innerHTML = "You might want to check your console for errors";
-  			}
-  		}, 3000);
-  		
+  		// try to connect to the SocketIO server (namespace MVP)
 	    var socket = io.connect("http://localhost:5000/mvp");
-	        socket.on('connect', function() {
-	        	statusElement.innerHTML = "<p> - Connected to SocketIO namespace 'MVP'</p>";
+	    var room = 'default';
+	    var token; // "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOjEsImV4cCI6MTQ0NjIzOTY4NywiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSJ9.keG6LDBHwlw_Wp7QV1ql4BoDW0I4TSd0uFqaS6TLm3s";
+	    var payload;
+	    // alert the client of successful connections
+        socket.on('connect', function() {
+        	statusElement.innerHTML = "<p> - Connected to SocketIO namespace 'MVP'</p>";
+        	
+        	authFormElement.style.display = "";
+        	$(authFormElement).submit(function(event) {
+        		event.preventDefault();
+        		authFormElement.style.display = "none";
+        		
+        		token = $("#jwt").val();
+        		payload = JSON.parse(atob(token.split('.')[1]));
+        		
+        		// fire off a request to join the default room
+	        	socket.emit('join', JSON.stringify({'token': token, 'room': room}));
 	        });
-	        socket.on('error', function(error) {
-	        	statusElement.innerHTML += "<p style='color:red'> - Error: " + error + "</p>";
-	        });
-	        socket.on('joined', function(data) {
-	        	statusElement.innerHTML += "<p> - Joined room '" + data['room'] + "'</p>"
-	        });
-	        
-	        var token = "test_token_here";
-	        socket.emit('join', JSON.stringify({'token': token, 'room': 'default'}));
+        });
+        // alert the client of errors
+        socket.on('error', function(error) {
+        	statusElement.innerHTML += "<p style='color:red'> - Error: " + error + "</p>";
+        });
+        // alert the client when a room has been joined successfully
+        // then set up the textbox immediately after
+        socket.on('joined', function(data) {
+        	statusElement.innerHTML += "<p> - Joined room '" + data['room'] + "'</p>"
+        	messageFormElement.style.display = ""; 	
+        });
+        // show the user what's going on with the socket on update
+        socket.on('updated', function(data) {
+        	statusElement.innerHTML += "<p> - " + data.sender + " is typing: " + data.message + "</p>";
+        });
+        // show the user when a message was sent (finalized)
+        socket.on('sent', function(data) {
+        	statusElement.innerHTML += "<p style='color:green'> - " + data.sender + " sent: " + data.message + "</p>";
+        });
+        
+        // handle when the user types something
+        $('#message').on('keyup', function(event) {
+        	var val = $(this).val();
+        	if (val.trim() === '') return;
+        	socket.emit('updated', JSON.stringify({'sender': payload.email, 'room': room, 'message': val}));
+        });
+           
+           // handle when the user sends the message
+        $(messageFormElement).submit(function (event) {
+             event.preventDefault();
+             var val = $('#message').val().trim();
+             if (val === "") return false;
+             socket.emit('sent', JSON.stringify({'sender': payload.email, 'room': room, 'message': val}));
+             
+             $('#message').val('');
+           })
+            
 	} catch (e) {
 		statusElement.innerHTML = e;
 	}

--- a/test/socket_test.html
+++ b/test/socket_test.html
@@ -4,6 +4,10 @@
     html {
       margin: 20px;
     }
+    p {
+      margin-top: 0px;
+      margin-bottom: 0px;
+    }
   </style>
 </head>
 <body>
@@ -21,10 +25,19 @@
   			}
   		}, 3000);
   		
-	    var socket = io.connect("http://localhost:5000");
+	    var socket = io.connect("http://localhost:5000/mvp");
 	        socket.on('connect', function() {
-	        	statusElement.innerHTML = 'Connected';
+	        	statusElement.innerHTML = "<p> - Connected to SocketIO namespace 'MVP'</p>";
 	        });
+	        socket.on('error', function(error) {
+	        	statusElement.innerHTML += "<p style='color:red'> - Error: " + error + "</p>";
+	        });
+	        socket.on('joined', function(data) {
+	        	statusElement.innerHTML += "<p> - Joined room '" + data['room'] + "'</p>"
+	        });
+	        
+	        var token = "test_token_here";
+	        socket.emit('join', JSON.stringify({'token': token, 'room': 'default'}));
 	} catch (e) {
 		statusElement.innerHTML = e;
 	}


### PR DESCRIPTION
Summary of changes:
- Added decorators for requiring certain endpoints/events to be authenticated
- Added `SocketSetupService` to handle initial SocketIO setup
- Added event handlers to facilitate authenticated chat in a single room (for the MVP)
- Updated `socket_test` to act as a simple integration test

Tasks completed
- [Websocket endpoint for chat](https://trello.com/c/TstgKpVS/6-websocket-endpoint-for-chat)

Notes:
- This is already touched-upon in the code, however it is worth re-iterating here that the `authenticated_request` decorator needs to be tested more before it is used. Errors should be minimal there, but may be present
- Since this feature is tailored to the development of the MVP, there will definitely be things that need to be refactored in the future
