### PR TITLE
Upgrade SocketIO to v1 Beta

### DIFF
--- a/config.py
+++ b/config.py
@@ -44,6 +44,7 @@ class _BaseConfig(object):
     SECRET_KEY = os.getenv('CONVERSATIONIM_API_SECRET', 'https://open.spotify.com/track/64i1dyG9Td5z5Q0TCG17Pb')
     LOGGING_LEVEL = NOTSET
     SQLALCHEMY_DATABASE_URI = _build_sql_uri()
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
     JWT_PARAMS = {
 		'ALGORITHM' : 'HS256',
 		'EXPIRATION_IN_DAYS': 7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 flask-restful>=0.3.4,<0.4.0
-flask-socketio>=0.6.0,<0.7.0
+flask-socketio==1.0b4
 flask-sqlalchemy>=2.0,<=2.1,
 
 MySQL-python>=1.2.5,

--- a/test/socket_test.html
+++ b/test/socket_test.html
@@ -23,7 +23,7 @@
     <input id="message" autocomplete="off" />
     <button>Send</button>
   </form>
-  <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/socket.io/0.9.16/socket.io.min.js"></script>
+  <script type="text/javascript" src="https://cdn.socket.io/socket.io-1.3.7.js"></script>
   <script src="http://code.jquery.com/jquery-latest.min.js"></script>
   <script type="text/javascript" charset="utf-8">
   	var statusElement = document.getElementById("status");


### PR DESCRIPTION
SocketIO v1.x is not backwards-compatible with v0.x, which we are currently using. However, the Android SocketIO client is built with v1.x, so we need to get our dependencies updated.

Tasks completed:
- Upgrade SocketIO to version 1.0b4 (1.0 Beta 4)
- Updated `socket_test` integration test
