### PR TITLE
Socket Initialization Fixes

### DIFF
--- a/app/sockets/service.py
+++ b/app/sockets/service.py
@@ -10,99 +10,83 @@ class SocketService(object):
     Handles operations related to conversations in the
     context of sockets
     """
-    
-    # maps email address to socket IDs 
+
+    # maps email address to socket IDs
     # (both global and conversation)
     _sockets = {}
-    
+
     @staticmethod
     def enter_conversation(conversation_id, participant):
         """
         Adds a participant to a conversation,
         creating a new one if one with the given
         conversation_id does not already exist
-        
+
         :conversation_id  a unique ID for a specific conversation
         :participant      the email address of the participant
         """
-        
+
         if not participant in SocketService._sockets:
             return
 
-        socket_id = SocketService._sockets[participant]['conversation']
+        socket_id = SocketService._sockets[participant]
         socketio = current_app.extensions['socketio']
         socketio.server.enter_room(socket_id, conversation_id, namespace='/conversation')
-        
+
     @staticmethod
     def _get_conversations(socket_id):
         """
         Provides a list of conversations in which a
         participant is participating
-        
+
         :socket_id     the 'conversation' socket ID for the participant
         """
-        
+
         socketio = current_app.extensions['socketio']
         return socketio.server.rooms(socket_id, namespace='/conversation')
-    
+
     @staticmethod
-    def add_global_identifier(email, socket_id):
+    def initialize_connection(email, socket_id):
         """
         Adds the provided socket ID to the internal mapping
         of users to socket IDs
-        
+
         :email        the email address of a user
         :socket_id    the 'global' socket ID for the user
         """
-        
-        SocketService._sockets[email] = { 'global': socket_id }
-    
-    @staticmethod
-    def add_conversation_identifier(email, socket_id):
-        """
-        Adds the provided socket ID to the internal mapping
-        of users to socket IDs. Raises InvalidOperationException
-        if called before add_global_identifier
-        
-        :email        the email address of a user
-        :socket_id    the 'conversation' socket ID for the user
-        """
-        
-        if email not in SocketService._sockets:
-            raise InvalidOperationException("The global namespace must be initialized before this namespace")
-        SocketService._sockets[email]['conversation'] = socket_id
-        
+
+        SocketService._sockets[email] = socket_id
+
     @staticmethod
     def create_conversation(conversation_id, creator, participants):
         """
         Creates a new conversation, returning a list of the participants
         who were successfully added to the conversation. Users who are not
         online cannot be added to a conversation
-        
-        
+
+
         :conversation_id a unique ID for the new conversation
         :creator         the email address of the conversation's creator
         :participants    a list of email addresses representing the desired participants
         """
-        
+
         result = []
         SocketService.enter_conversation(conversation_id, creator)
-        
+
         for participant in participants:
             if participant in SocketService._sockets:
-                global_socket_id = SocketService._sockets[participant]['global']
-                conversation_socket_id = SocketService._sockets[participant]['conversation']
-                
+                socket_id = SocketService._sockets[participant]
+
                 # we trick socketIO into thinking that we're in
                 # a socket context here so that we can emit what we want
                 request.namespace = '/global'
-                request.sid = global_socket_id
-                
-                SocketService._enter_conversation(conversation_socket_id, conversation_id, participant)
+                request.sid = socket_id
+
+                SocketService.enter_conversation(conversation_id, participant)
                 emit('added', {'conversationId': conversation_id, 'creator': creator})
-                
+
                 result.append(participant)
-                
+
         return result
 
     @staticmethod
@@ -110,10 +94,10 @@ class SocketService(object):
         """
         Removes the provided email from the internal mapping
         of users to socket IDs
-        
+
         :email        the email address of a user
         """
-        
+
         if email in SocketService._sockets:
             del SocketService._sockets[email]
 
@@ -121,14 +105,14 @@ class SocketService(object):
     def leave_conversation(conversation_id, participant):
         """
         Removes a participant from a conversation
-        
+
         :conversation_id  a unique ID for a specific conversation
         :participant      the email address of the participant
         """
         if not participant in SocketService._sockets:
             return
 
-        socket_id = SocketService._sockets[participant]['conversation']
+        socket_id = SocketService._sockets[participant]
         socketio = current_app.extensions['socketio']
         socketio.server.leave_room(socket_id, conversation_id, namespace='/conversation')
 
@@ -142,52 +126,32 @@ class SocketService(object):
 
         socketio = current_app.extensions['socketio']
         socketio.server.close_room(conversation_id, namespace = '/conversation')
-        
+
 
 class SocketSetupService(object):
- 
+
     @staticmethod
     def setup_handlers(socketio):
-        
+
         @socketio.on('initialize', namespace="/global")
         @authenticated_event
         def global_init(raw_data, data=None, user=None, error=None):
             if not user:
                 emit('error', "Authentication is required to initialize this namespace")
+                return
             if error:
                 emit('error', error)
-                
-            SocketService.add_global_identifier(user['email'], request.sid)
-            
-        @socketio.on('initialize', namespace="/conversation")
-        @authenticated_event
-        def conversation_init(raw_data, data=None, user=None, error=None):
-            if not user:
-                emit('error', "Authentication is required to initialize this namespace")
-            if error:
-                emit('error', error)
-            try:
-                SocketService.add_conversation_identifier(user['email'], request.sid)
-            except InvalidOperationException, e:
-                emit('error', e.message)
+                return
 
-        @socketio.on('disconnect', namespace="/global")
-        @authenticated_event
-        def global_disconnect(raw_data, data=None, user=None, error=None):
-            if not user:
-                emit('error', "Authentication is required to disconnect this namespace")
-            if error:
-                emit('error', error)
-                
-            SocketService.remove_identifier(user['email'])
+            SocketService.initialize_connection(user['email'], request.sid)
 
         @socketio.on('updated', namespace="/conversation")
         def conversation_update(json):
             if type(json) is not dict:
                 data = loads(json)
-            
+
             emit('updated', data, room=data.get('conversationId'))
-             
+
         @socketio.on('sent', namespace="/conversation")
         def conversation_send(json):
             if type(json) is not dict:

--- a/test/socket_test.html
+++ b/test/socket_test.html
@@ -1,4 +1,4 @@
-<!-- WARNING: this is a crude integration test meant to quickly test functionality. 
+<!-- WARNING: this is a crude integration test meant to quickly test functionality.
 
 As such, It will not work in most modern browsers without disabling certain security features
 (this is a good thing). The reason for this is related to the fact that this test will attempt to make
@@ -77,57 +77,52 @@ Nevertheless if you are using Chrome and would like to see the results of this t
             token = $("#jwt").val();
             payload = JSON.parse(atob(token.split('.')[1]));
 
-            // initialize both connections (global's initialization MUST come first)
-            // or an error will be sent back
+            // initialize connection
             global.emit('initialize', JSON.stringify({
               'token': token
             }), function() {
-              conversation.emit('initialize', JSON.stringify({
-                'token': token
-              }), function() {
-                // once both are initialized, we're ready to go
-                // so show a button to create a new convo to the user admin@example.com
-                if (payload['email'] === 'admin@example.com') {
-                  $('#createConvo').show();
-                  $('#createConvo').on('click', function(event) {
-                    event.preventDefault();
+              // once initialized, we're ready to go
+              // so show a button to create a new convo to the user admin@example.com
+              if (payload['email'] === 'admin@example.com') {
+                $('#createConvo').show();
+                $('#createConvo').on('click', function(event) {
+                  event.preventDefault();
 
-                    // on click, send up a request to the API to create a
-                    // new conversation with the participant test@example.com
-                    // NOTE: if test@example.com is not online, he/she will not be
-                    // added to the conversation!
-                    $.ajax({
-                      type: "POST",
-                      url: "http://localhost:5000/v1/conversation",
-                      data: JSON.stringify({
-                        "participants": ["test@example.com"]
-                      }),
-                      contentType: 'application/json; charset=utf-8',
-                      dataType: 'json',
-                      beforeSend: function(xhr) {
-                        xhr.setRequestHeader('Authorization', token);
-                      },
-                      success: function(response) {
-                        // hide the create conversation button on success
-                        $('#createConvo').hide();
+                  // on click, send up a request to the API to create a
+                  // new conversation with the participant test@example.com
+                  // NOTE: if test@example.com is not online, he/she will not be
+                  // added to the conversation!
+                  $.ajax({
+                    type: "POST",
+                    url: "http://localhost:5000/v1/conversation",
+                    data: JSON.stringify({
+                      "participants": ["test@example.com"]
+                    }),
+                    contentType: 'application/json; charset=utf-8',
+                    dataType: 'json',
+                    beforeSend: function(xhr) {
+                      xhr.setRequestHeader('Authorization', token);
+                    },
+                    success: function(response) {
+                      // hide the create conversation button on success
+                      $('#createConvo').hide();
 
-                        conversationId = response.data.conversationId;
-                        statusElement.innerHTML = "<p>You're now chatting with " + response.data.participants + ".</p>";
+                      conversationId = response.data.conversationId;
+                      statusElement.innerHTML = "<p>You're now chatting with " + response.data.participants + ".</p>";
 
-                        messageFormElement.style.display = "";
-                      },
-                      error: function(error) {
-                        console.log("There was an error: ", error);
-                      }
-                    });
+                      messageFormElement.style.display = "";
+                    },
+                    error: function(error) {
+                      console.log("There was an error: ", error);
+                    }
                   });
-                } else {
-                  // if the user isn't the specific user that we're allowing to start conversations,
-                  // just show a 'waiting' message
-                  // NOTE: any user can create conversations in the real app!
-                  $(statusElement).append("<p>- Waiting for incoming conversations</p>");
-                }
-              });
+                });
+              } else {
+                // if the user isn't the specific user that we're allowing to start conversations,
+                // just show a 'waiting' message
+                // NOTE: any user can create conversations in the real app!
+                $(statusElement).append("<p>- Waiting for incoming conversations</p>");
+              }
             });
           });
         });
@@ -175,6 +170,7 @@ Nevertheless if you are using Chrome and would like to see the results of this t
           'message': val
         }));
 
+        statusElement.innerHTML += "<p style='color:green'> - " + payload.email + " sent: " + val + "</p>";
         $('#message').val('');
       });
     } catch (e) {


### PR DESCRIPTION
While working to finish up development of the Android app, it became clear that the method by which we were mapping usernames to socket IDs was overly redundant. As a consequence, tiny inconsistencies in how the front-end was initializing the socket channels was causing the mappings to be overwritten.

As such, this fix makes the following changes:
- Use the same `request.sid` to emit events to connected clients on all namespaces
- Do not try to remove socket ID mappings on disconnect

Tasks:
- N/A

The integration test has also been updated to reflect these changes.
